### PR TITLE
[MZUR-250] Add picked_at to order_items

### DIFF
--- a/database/migrations/2024_06_26_080126_add_picked_at_to_order_items.php
+++ b/database/migrations/2024_06_26_080126_add_picked_at_to_order_items.php
@@ -1,0 +1,29 @@
+<?php
+
+use Domain\Statuses\Models\Status;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('order_items', function (Blueprint $table) {
+            $table->foreignIdFor(Status::class)->nullable()->after('item_id')
+                ->constrained()
+                ->cascadeOnDelete()
+                ->cascadeOnUpdate();
+            $table->dateTime('picked_at')->nullable()->after('status_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('order_items', function (Blueprint $table) {
+            $table->dropForeign(['status_id']);
+            $table->dropColumn('status_id');
+            $table->dropColumn('picked_at');
+        });
+    }
+};


### PR DESCRIPTION
Added a picked_at timestamp to order items to determine whether they've been picked
I may also add a status column, but trying this out for now. Statuses are user-defined, and could potentially get messy relying on those to determine picked status. This also aligns with the pattern I set up in the `item_storage_location` table of using a timestamp, rather than a status
